### PR TITLE
Fix DateTimeFormatter.timezone for negative UTC offset

### DIFF
--- a/lib/assets/javascripts/twitter_cldr/af.js
+++ b/lib/assets/javascripts/twitter_cldr/af.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/ar.js
+++ b/lib/assets/javascripts/twitter_cldr/ar.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/ca.js
+++ b/lib/assets/javascripts/twitter_cldr/ca.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/cs.js
+++ b/lib/assets/javascripts/twitter_cldr/cs.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/da.js
+++ b/lib/assets/javascripts/twitter_cldr/da.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/de.js
+++ b/lib/assets/javascripts/twitter_cldr/de.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/el.js
+++ b/lib/assets/javascripts/twitter_cldr/el.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/en.js
+++ b/lib/assets/javascripts/twitter_cldr/en.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/es.js
+++ b/lib/assets/javascripts/twitter_cldr/es.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/eu.js
+++ b/lib/assets/javascripts/twitter_cldr/eu.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/fa.js
+++ b/lib/assets/javascripts/twitter_cldr/fa.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/fi.js
+++ b/lib/assets/javascripts/twitter_cldr/fi.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/fil.js
+++ b/lib/assets/javascripts/twitter_cldr/fil.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/fr.js
+++ b/lib/assets/javascripts/twitter_cldr/fr.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/he.js
+++ b/lib/assets/javascripts/twitter_cldr/he.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/hi.js
+++ b/lib/assets/javascripts/twitter_cldr/hi.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/hu.js
+++ b/lib/assets/javascripts/twitter_cldr/hu.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/id.js
+++ b/lib/assets/javascripts/twitter_cldr/id.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/it.js
+++ b/lib/assets/javascripts/twitter_cldr/it.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/ja.js
+++ b/lib/assets/javascripts/twitter_cldr/ja.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/ko.js
+++ b/lib/assets/javascripts/twitter_cldr/ko.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/msa.js
+++ b/lib/assets/javascripts/twitter_cldr/msa.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/nl.js
+++ b/lib/assets/javascripts/twitter_cldr/nl.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/no.js
+++ b/lib/assets/javascripts/twitter_cldr/no.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/pl.js
+++ b/lib/assets/javascripts/twitter_cldr/pl.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/pt.js
+++ b/lib/assets/javascripts/twitter_cldr/pt.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/ru.js
+++ b/lib/assets/javascripts/twitter_cldr/ru.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/sv.js
+++ b/lib/assets/javascripts/twitter_cldr/sv.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/th.js
+++ b/lib/assets/javascripts/twitter_cldr/th.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/tr.js
+++ b/lib/assets/javascripts/twitter_cldr/tr.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/uk.js
+++ b/lib/assets/javascripts/twitter_cldr/uk.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/ur.js
+++ b/lib/assets/javascripts/twitter_cldr/ur.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/zh-cn.js
+++ b/lib/assets/javascripts/twitter_cldr/zh-cn.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/assets/javascripts/twitter_cldr/zh-tw.js
+++ b/lib/assets/javascripts/twitter_cldr/zh-tw.js
@@ -407,7 +407,7 @@ TwitterCldr.DateTimeFormatter = DateTimeFormatter = (function() {
       case 3:
         return offsetString;
       default:
-        return "UTC " + offsetString;
+        return "UTC" + offsetString;
     }
   };
 

--- a/lib/twitter_cldr/js/mustache/calendars/datetime.coffee
+++ b/lib/twitter_cldr/js/mustache/calendars/datetime.coffee
@@ -239,7 +239,7 @@ TwitterCldr.DateTimeFormatter = class DateTimeFormatter
 			when 1, 2, 3
 				offsetString
 			else
-				"UTC " + offsetString
+				"UTC" + offsetString
 
 	timezone_generic_non_location: (time, pattern, length) ->
 		throw 'not yet implemented (requires timezone translation data")'

--- a/spec/js/calendars/datetime.spec.js
+++ b/spec/js/calendars/datetime.spec.js
@@ -346,7 +346,7 @@ describe("DateTimeFormatter", function() {
       expect(formatter.timezone(date, 'z', 1)).toMatch(/^(-|\+)\d{2}:\d{2}$/);
       expect(formatter.timezone(date, 'zz', 2)).toMatch(/^(-|\+)\d{2}:\d{2}$/);
       expect(formatter.timezone(date, 'zzz', 3)).toMatch(/^(-|\+)\d{2}:\d{2}$/);
-      expect(formatter.timezone(date, 'zzzz', 4)).toMatch(/^UTC (-|\+)\d{2}:\d{2}$/);
+      expect(formatter.timezone(date, 'zzzz', 4)).toMatch(/^UTC(-|\+)\d{2}:\d{2}$/);
     });
   });
 


### PR DESCRIPTION
Fixes #4. The problem was with timezones that have negative UTC offset, e.g., UTC+3. 

I also removed space from full time zone format, because it's seems like this space is usually omitted (correct me if I'm wrong or it's a part of some standard). Now it looks like `"UTC±07:00"`.
