### PR TITLE
Remove version requirement from rake development dependency

### DIFF
--- a/twitter_cldr_js.gemspec
+++ b/twitter_cldr_js.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'twitter_cldr', '~> 2.4.0'
   s.add_dependency 'railties', '~> 3.1'
 
-  s.add_development_dependency 'rake', '~> 0.9.2.2'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'mustache', '~> 0.99.4'
   s.add_development_dependency 'ruby_parser', '~> 2.3.1'
   s.add_development_dependency 'therubyracer',  '~> 0.11.4'


### PR DESCRIPTION
@camertron - simple change to the gemspec to allow for any version of `rake`.

Should fix https://github.com/twitter/twitter-cldr-js/issues/21
