### PR TITLE
Bower package definition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "twitter-cldr-js",
+  "version": "2.2.1",
+  "homepage": "https://github.com/twitter/twitter-cldr-js",
+  "authors": [
+    "Cameron C. Dutro"
+  ],
+  "description": "CLDR bindings for Javascript",
+  "main": "lib/assets/javascripts",
+  "keywords": [
+    "cldr"
+  ],
+  "license": "Apache 2.0",
+  "private": true,
+  "root": "lib/assets/javascripts",
+  "ignore": [
+    "**/.*",
+    "spec",
+    "Gemfile",
+    "*.gemspec",
+    "lib/twitter_cldr",
+    "History.txt",
+    "NOTICE",
+    "git-diff"
+  ]
+}


### PR DESCRIPTION
@camertron

Though `twitter-cldr-js` went from being a set of JS files to being a
gem whose primary goal is to integrate with the Rails assets pipeline, there is
value in defining a Bower package for JS developers who simply want to make
use of CLDR from, e.g., their Node code.

I have no experience defining Bower packages and might have missed something —
it looks like the package manager will simply pull the entire git repo (at least that's
what happened when I tried to test locally). It's not a very big deal anyway, since
developers should ultimately filter and compile the `.js` files when their project is 
deployed. The file was automatically generated by `bower init` and refers to the latest
git tag (2.2.1), which isn't the latest release on rubygems.org (what gives?)

In any case, Bower being a project maintained by Twitter, I think it'd be nice to have
some amount of coordination between their project and this one.
