### PR TITLE
Refactor bundle creation logic

### DIFF
--- a/lib/twitter_cldr/js/compiler.rb
+++ b/lib/twitter_cldr/js/compiler.rb
@@ -27,8 +27,7 @@ module TwitterCldr
 
         contents = ""
         bundle_elements.each do |bundle_element|
-          renderer_const = bundle_hash[bundle_element]
-          if renderer_const
+          if renderer_const = bundle_hash[bundle_element]
             if bundle[:locale]
               contents << renderer_const.new(:locale => bundle[:locale], :prerender => @prerender).render
             else
@@ -60,7 +59,6 @@ module TwitterCldr
 
       def compile_each(options = {})
         @locales.each do |locale|
-          contents = ""
           bundle = TwitterCldr::Js::Renderers::Bundle.new
           bundle[:locale] = locale
           file = compile_bundle(bundle, @features, implementation_renderers, options)

--- a/lib/twitter_cldr/js/compiler.rb
+++ b/lib/twitter_cldr/js/compiler.rb
@@ -22,50 +22,21 @@ module TwitterCldr
         @source_map = options[:source_map]
       end
 
-      def compile_each(options = {})
-        options[:minify] = true unless options.include?(:minify)
-
-        @locales.each do |locale|
-          contents = ""
-
-          @features.each do |feature|
-            renderer_const = implementation_renderers[feature]
-            contents << renderer_const.new(:locale => locale, :prerender => @prerender).render if renderer_const
-          end
-
-          bundle = TwitterCldr::Js::Renderers::Bundle.new
-          bundle[:locale] = locale
-          bundle[:contents] = contents
-          bundle[:source_map] = @source_map
-
-          result = CoffeeScript.compile(bundle.render, {
-            :bare => false,
-            :sourceMap => @source_map
-          })
-
-          file = if @source_map
-            CompiledFile.new(result["js"], result["sourceMap"])
-          else
-            CompiledFile.new(result)
-          end
-
-          # required alias definition that adds twitter_cldr to Twitter's static build process
-          file.source.gsub!(/\/\*<<module_def>>\s+\*\//, %Q(/*-module-*/\n/*_lib/twitter_cldr_*/))
-          file.source = Uglifier.compile(file.source) if options[:minify]
-
-          yield file, TwitterCldr.twitter_locale(locale)
-        end
-      end
-
-      def compile_test(options = {})
+      def compile_bundle(bundle, bundle_elements, bundle_hash, options = {})
         options[:minify] = true unless options.include?(:minify)
 
         contents = ""
-        @test_helpers.each do |test_helper|
-          renderer_const = test_helper_renderers[test_helper]
-          contents << renderer_const.new(:prerender => @prerender).render if renderer_const
+        bundle_elements.each do |bundle_element|
+          renderer_const = bundle_hash[bundle_element]
+          if renderer_const
+            if bundle[:locale]
+              contents << renderer_const.new(:locale => bundle[:locale], :prerender => @prerender).render
+            else
+              contents << renderer_const.new(:prerender => @prerender).render
+            end
+          end
         end
-        bundle = TwitterCldr::Js::Renderers::TestBundle.new
+
         bundle[:contents] = contents
         bundle[:source_map] = @source_map
 
@@ -84,6 +55,23 @@ module TwitterCldr
         file.source.gsub!(/\/\*<<module_def>>\s+\*\//, %Q(/*-module-*/\n/*_lib/twitter_cldr_*/))
         file.source = Uglifier.compile(file.source) if options[:minify]
 
+        file
+      end
+
+      def compile_each(options = {})
+        @locales.each do |locale|
+          contents = ""
+          bundle = TwitterCldr::Js::Renderers::Bundle.new
+          bundle[:locale] = locale
+          file = compile_bundle(bundle, @features, implementation_renderers, options)
+
+          yield file, TwitterCldr.twitter_locale(locale)
+        end
+      end
+
+      def compile_test(options = {})
+        bundle = TwitterCldr::Js::Renderers::TestBundle.new
+        file = compile_bundle(bundle, @test_helpers, test_helper_renderers, options)
         file.source
       end
 

--- a/lib/twitter_cldr/js/tasks/tasks.rb
+++ b/lib/twitter_cldr/js/tasks/tasks.rb
@@ -52,7 +52,7 @@ module TwitterCldr
             options[:files].each_pair do |file_pattern, minify|
               compiler.compile_each(:minify => minify) do |bundle, locale|
                 out_file_path = [output_dir, file_pattern % locale]
-                write_bundle(out_file_path, bundle.source)
+                write_file(out_file_path, bundle.source)
 
                 if bundle.source_map
                   ext = File.extname(out_file)
@@ -63,7 +63,7 @@ module TwitterCldr
 
             if options[:render_test_files]
               file_contents = compiler.compile_test()
-              write_bundle([output_dir, 'test_resources.js'], file_contents)
+              write_file([output_dir, 'test_resources.js'], file_contents)
             end
 
           end
@@ -75,20 +75,8 @@ module TwitterCldr
           )
         end
 
-        def write_bundle(file_path, file_contents)
-          out_file = file_path
-
-          if file_path.is_a?(Array)
-            out_file = File.join(file_path)
-          end
-
-          write_file(out_file, file_contents)
-        end
-
-        def write_file(file_name, file_contents)
-          File.open(file_name, "w+") do |f|
-            f.write(file_contents)
-          end
+        def write_file(file_path, file_contents)
+          File.write(File.join(file_path), file_contents)
         end
 
         def build_summary(options = {})

--- a/lib/twitter_cldr/js/tasks/tasks.rb
+++ b/lib/twitter_cldr/js/tasks/tasks.rb
@@ -51,28 +51,19 @@ module TwitterCldr
           build_duration = time_operation do
             options[:files].each_pair do |file_pattern, minify|
               compiler.compile_each(:minify => minify) do |bundle, locale|
-                out_file = File.join(output_dir, file_pattern % locale)
-                FileUtils.mkdir_p(File.dirname(out_file))
-                File.open(out_file, "w+") do |f|
-                  f.write(bundle.source)
-                end
+                out_file_path = [output_dir, file_pattern % locale]
+                write_bundle(out_file_path, bundle.source)
 
                 if bundle.source_map
                   ext = File.extname(out_file)
-                  File.open("#{out_file.chomp(ext)}.map", "w+") do |f|
-                    f.write(bundle.source_map)
-                  end
+                  write_file("#{out_file.chomp(ext)}.map", bundle.source_map)
                 end
               end
             end
 
             if options[:render_test_files]
               file_contents = compiler.compile_test()
-              out_file = File.join(output_dir, 'test_resources.js')
-              FileUtils.mkdir_p(File.dirname(out_file))
-              File.open(out_file, "w+") do |f|
-                f.write(file_contents)
-              end
+              write_bundle([output_dir, 'test_resources.js'], file_contents)
             end
 
           end
@@ -82,6 +73,22 @@ module TwitterCldr
             :build_duration => build_duration,
             :dir => output_dir
           )
+        end
+
+        def write_bundle(file_path, file_contents)
+          out_file = file_path
+
+          if file_path.is_a?(Array)
+            out_file = File.join(file_path)
+          end
+
+          write_file(out_file, file_contents)
+        end
+
+        def write_file(file_name, file_contents)
+          File.open(file_name, "w+") do |f|
+            f.write(file_contents)
+          end
         end
 
         def build_summary(options = {})


### PR DESCRIPTION
 Extracting re-used code into separate methods. This is a precursor to data/logic separation.

@camertron @KL-7 

I should have done this with #60 