### PR TITLE
Fix RBNF Tokenizer rule recogniser and add a NotImplementedException error subclass

### DIFF
--- a/lib/assets/javascripts/twitter_cldr/core.js
+++ b/lib/assets/javascripts/twitter_cldr/core.js
@@ -17,9 +17,9 @@
 
 (function() {
   var TwitterCldr, key, obj, root,
-    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
     __hasProp = {}.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   TwitterCldr = {};
 
@@ -214,6 +214,18 @@
     return Utilities;
 
   })();
+
+  TwitterCldr.NotImplementedException = (function(_super) {
+    __extends(NotImplementedException, _super);
+
+    function NotImplementedException(message) {
+      this.message = message != null ? message : "";
+      NotImplementedException.__super__.constructor.apply(this, arguments);
+    }
+
+    return NotImplementedException;
+
+  })(Error);
 
   TwitterCldr.Settings = (function() {
     function Settings() {}
@@ -3419,18 +3431,8 @@
 
   TwitterCldr.RBNFTokenizer = (function() {
     function RBNFTokenizer() {
-      var component, r, recognizers, splitter, splitter_source, word_regex, word_regex_components;
-      word_regex_components = [TwitterCldr.CodePoint.code_points_for_property("category", "Ll"), TwitterCldr.CodePoint.code_points_for_property("category", "Lm"), TwitterCldr.CodePoint.code_points_for_property("category", "Lo"), TwitterCldr.CodePoint.code_points_for_property("category", "Lt"), TwitterCldr.CodePoint.code_points_for_property("category", "Lu"), TwitterCldr.CodePoint.code_points_for_property("category", "Mc"), TwitterCldr.CodePoint.code_points_for_property("category", "Me"), TwitterCldr.CodePoint.code_points_for_property("category", "Mu"), TwitterCldr.CodePoint.code_points_for_property("category", "Nd"), TwitterCldr.CodePoint.code_points_for_property("category", "Nl"), TwitterCldr.CodePoint.code_points_for_property("category", "No"), TwitterCldr.CodePoint.code_points_for_property("category", "Pc"), TwitterCldr.CodePoint.code_points_for_property("category", "Pd")];
-      word_regex = "(" + (((function() {
-        var _i, _len, _results;
-        _results = [];
-        for (_i = 0, _len = word_regex_components.length; _i < _len; _i++) {
-          component = word_regex_components[_i];
-          _results.push(component);
-        }
-        return _results;
-      })()).join("|")) + ")+";
-      recognizers = [new TwitterCldr.TokenRecognizer("negative", new RegExp(/-x/)), new TwitterCldr.TokenRecognizer("improper_fraction", new RegExp(/x\.x/)), new TwitterCldr.TokenRecognizer("proper_fraction", new RegExp(/0\.x/)), new TwitterCldr.TokenRecognizer("master", new RegExp(/x\.0/)), new TwitterCldr.TokenRecognizer("equals", new RegExp(/\=/)), new TwitterCldr.TokenRecognizer("rule", new RegExp("%%?" + word_regex)), new TwitterCldr.TokenRecognizer("right_arrow", new RegExp(/>/)), new TwitterCldr.TokenRecognizer("left_arrow", new RegExp(/</)), new TwitterCldr.TokenRecognizer("open_bracket", new RegExp(/\[/)), new TwitterCldr.TokenRecognizer("close_bracket", new RegExp(/\]/)), new TwitterCldr.TokenRecognizer("decimal", new RegExp(/[0#][0#,\.]+/)), new TwitterCldr.TokenRecognizer("plural", new RegExp(/\$\(.*\)\$/)), new TwitterCldr.TokenRecognizer("semicolon", new RegExp(/;/))];
+      var r, recognizers, splitter, splitter_source;
+      recognizers = [new TwitterCldr.TokenRecognizer("negative", new RegExp(/-x/)), new TwitterCldr.TokenRecognizer("improper_fraction", new RegExp(/x\.x/)), new TwitterCldr.TokenRecognizer("proper_fraction", new RegExp(/0\.x/)), new TwitterCldr.TokenRecognizer("master", new RegExp(/x\.0/)), new TwitterCldr.TokenRecognizer("equals", new RegExp(/\=/)), new TwitterCldr.TokenRecognizer("rule", TwitterCldr.RBNFTokenizer.get_rule_regexp()), new TwitterCldr.TokenRecognizer("right_arrow", new RegExp(/>/)), new TwitterCldr.TokenRecognizer("left_arrow", new RegExp(/</)), new TwitterCldr.TokenRecognizer("open_bracket", new RegExp(/\[/)), new TwitterCldr.TokenRecognizer("close_bracket", new RegExp(/\]/)), new TwitterCldr.TokenRecognizer("decimal", new RegExp(/[0#][0#,\.]+/)), new TwitterCldr.TokenRecognizer("plural", new RegExp(/\$\(.*\)\$/)), new TwitterCldr.TokenRecognizer("semicolon", new RegExp(/;/))];
       splitter_source = "(" + (((function() {
         var _i, _len, _results;
         _results = [];
@@ -3448,6 +3450,23 @@
       var tokenizer;
       tokenizer = new TwitterCldr.PatternTokenizer(null, this.tokenizer);
       return tokenizer.tokenize(pattern);
+    };
+
+    RBNFTokenizer.get_rule_regexp = function() {
+      var component, word_regexp_components;
+      if (this.rule_regexp != null) {
+        return this.rule_regexp;
+      }
+      word_regexp_components = ["Ll", "Lm", "Lo", "Lt", "Lu", "Mc", "Me", "Mu", "Nd", "Nl", "No", "Pc", "Pd"];
+      return this.rule_regexp = TwitterCldr.UnicodeRegex.compile("%%?[" + ((function() {
+        var _i, _len, _results;
+        _results = [];
+        for (_i = 0, _len = word_regexp_components.length; _i < _len; _i++) {
+          component = word_regexp_components[_i];
+          _results.push("[:" + component + ":]");
+        }
+        return _results;
+      })()).join("") + "]*").to_regexp();
     };
 
     return RBNFTokenizer;
@@ -4138,13 +4157,13 @@
           if (rule_set.is_public()) {
             return TwitterCldr.RBNFRuleFormatter.format(number, rule_set, rule_group, this.locale);
           } else {
-            throw rule_set_name + " is a private rule set and cannot be used directly.";
+            throw "" + rule_set_name + " is a private rule set and cannot be used directly.";
           }
         } else {
-          throw "rule set - " + rule_set_name + " - not implemented";
+          throw new TwitterCldr.NotImplementedException("rule set - " + rule_set_name + " - not implemented");
         }
       } else {
-        throw "rule group - " + rule_group_name + " - not implemented";
+        throw new TwitterCldr.NotImplementedException("rule group - " + rule_group_name + " - not implemented");
       }
     };
 

--- a/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/rbnf.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/rbnf.coffee
@@ -28,11 +28,11 @@ class TwitterCldr.RBNF
         if rule_set.is_public()
           TwitterCldr.RBNFRuleFormatter.format(number, rule_set, rule_group, @locale)
         else
-          throw rule_set_name + " is a private rule set and cannot be used directly."
+          throw "#{rule_set_name} is a private rule set and cannot be used directly."
       else
-        throw "rule set - #{rule_set_name} - not implemented"
+        throw new TwitterCldr.NotImplementedException("rule set - #{rule_set_name} - not implemented")
     else
-      throw "rule group - #{rule_group_name} - not implemented"
+      throw new TwitterCldr.NotImplementedException("rule group - #{rule_group_name} - not implemented")
 
   group_names : ->
     group['type'] for group in @get_resource_for_locale()

--- a/lib/twitter_cldr/js/mustache/utilities.coffee
+++ b/lib/twitter_cldr/js/mustache/utilities.coffee
@@ -142,3 +142,7 @@ class TwitterCldr.Utilities
       else
         return null
     value
+
+class TwitterCldr.NotImplementedException extends Error
+  constructor: (@message = "") ->
+    super

--- a/spec/js/numbers/rbnf.spec.js
+++ b/spec/js/numbers/rbnf.spec.js
@@ -27,14 +27,16 @@ function rbnf_test_case (locale, rule_group, rule_set, test_case) {
       TwitterCldr.set_data(data_backup);
     });
 
-    it('formats test_case correctly', function() {
+    it('formats ' + test_case + ' correctly', function() {
       try {
         var got = formatter.format(TwitterCldr.PluralRules.runtime.toNum(test_case), rule_group, rule_set);
         var expected = TwitterCldr.RBNF.test_resource[locale][rule_group][rule_set][test_case];
         expect(got).toEqual(expected);
       }
       catch (error) {
-        // Ignore `Not implemented` errors.
+        if (!(error instanceof TwitterCldr.NotImplementedException)) {
+            throw error;
+        }
       }
     });
   });


### PR DESCRIPTION
### Problem
While working on #62, I realised that some RBNF rules didn't work. (`Exception: Cannot call method 'rule_for' of null`).


### Cause
The RBNF tokenizer didn't tokenise some rules correctly. The Rule recognizer regex wasn't being generated properly because I was calling the wrong method(s) (oops!). This led to a few exceptions when querying a subset of the rules. This exception was being suppressed because the test was ignoring _all_ exceptions in the RNBF tests rather than only the tests for rules which weren't implemented. I've added a `NotImplementedException` error subclass and tests only skip on these errors now.

(Should I go ahead and throw this exception everywhere in the library where stuff isn't implemented? For instance [here](https://github.com/twitter/twitter-cldr-js/blob/b92a255c77d8864fecd377895ea137f0fb41afb0/lib/twitter_cldr/js/mustache/implementation/calendars/datetime.coffee#L100) or [here](https://github.com/twitter/twitter-cldr-js/blob/b92a255c77d8864fecd377895ea137f0fb41afb0/lib/twitter_cldr/js/mustache/implementation/calendars/datetime.coffee#L103))

#### Notes:
- This branched is based off of the branch for #62 and should be merged after that one is merged. Till then the change-set won't be of much help. 😅
- A downside of this is that now the tests take a really long time (there are about 30k tests). I've made [this PR](https://github.com/radzinzki/twitter-cldr-js/pull/1) to address this.

@KL-7 @camertron 