### PR TITLE
Shorten test runs by running only a subset of RBNF tests by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.2.0
-script: 'bundle exec rake'
+script: 'bundle exec rake spec:js:full'

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,17 @@ RSpec::Core::RakeTask.new("spec:ruby") do |t|
 end
 
 desc 'Run JavaScript specs'
+
 task "spec:js" do
+  run_tests()
+end
+
+task "spec:js:full" do
+  ENV["FULL_TEST_SUITE"] = "True"
+  run_tests()
+end
+
+def run_tests
   ENV["LOCALES"] = "en,ar,ko,ru,hi"
   Rake::Task["twitter_cldr:js:update_for_test"].invoke
 

--- a/lib/assets/javascripts/twitter_cldr/core.js
+++ b/lib/assets/javascripts/twitter_cldr/core.js
@@ -17,9 +17,9 @@
 
 (function() {
   var TwitterCldr, key, obj, root,
-    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
     __hasProp = {}.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
+    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   TwitterCldr = {};
 
@@ -214,6 +214,18 @@
     return Utilities;
 
   })();
+
+  TwitterCldr.NotImplementedException = (function(_super) {
+    __extends(NotImplementedException, _super);
+
+    function NotImplementedException(message) {
+      this.message = message != null ? message : "";
+      NotImplementedException.__super__.constructor.apply(this, arguments);
+    }
+
+    return NotImplementedException;
+
+  })(Error);
 
   TwitterCldr.Settings = (function() {
     function Settings() {}
@@ -3419,18 +3431,8 @@
 
   TwitterCldr.RBNFTokenizer = (function() {
     function RBNFTokenizer() {
-      var component, r, recognizers, splitter, splitter_source, word_regex, word_regex_components;
-      word_regex_components = [TwitterCldr.CodePoint.code_points_for_property("category", "Ll"), TwitterCldr.CodePoint.code_points_for_property("category", "Lm"), TwitterCldr.CodePoint.code_points_for_property("category", "Lo"), TwitterCldr.CodePoint.code_points_for_property("category", "Lt"), TwitterCldr.CodePoint.code_points_for_property("category", "Lu"), TwitterCldr.CodePoint.code_points_for_property("category", "Mc"), TwitterCldr.CodePoint.code_points_for_property("category", "Me"), TwitterCldr.CodePoint.code_points_for_property("category", "Mu"), TwitterCldr.CodePoint.code_points_for_property("category", "Nd"), TwitterCldr.CodePoint.code_points_for_property("category", "Nl"), TwitterCldr.CodePoint.code_points_for_property("category", "No"), TwitterCldr.CodePoint.code_points_for_property("category", "Pc"), TwitterCldr.CodePoint.code_points_for_property("category", "Pd")];
-      word_regex = "(" + (((function() {
-        var _i, _len, _results;
-        _results = [];
-        for (_i = 0, _len = word_regex_components.length; _i < _len; _i++) {
-          component = word_regex_components[_i];
-          _results.push(component);
-        }
-        return _results;
-      })()).join("|")) + ")+";
-      recognizers = [new TwitterCldr.TokenRecognizer("negative", new RegExp(/-x/)), new TwitterCldr.TokenRecognizer("improper_fraction", new RegExp(/x\.x/)), new TwitterCldr.TokenRecognizer("proper_fraction", new RegExp(/0\.x/)), new TwitterCldr.TokenRecognizer("master", new RegExp(/x\.0/)), new TwitterCldr.TokenRecognizer("equals", new RegExp(/\=/)), new TwitterCldr.TokenRecognizer("rule", new RegExp("%%?" + word_regex)), new TwitterCldr.TokenRecognizer("right_arrow", new RegExp(/>/)), new TwitterCldr.TokenRecognizer("left_arrow", new RegExp(/</)), new TwitterCldr.TokenRecognizer("open_bracket", new RegExp(/\[/)), new TwitterCldr.TokenRecognizer("close_bracket", new RegExp(/\]/)), new TwitterCldr.TokenRecognizer("decimal", new RegExp(/[0#][0#,\.]+/)), new TwitterCldr.TokenRecognizer("plural", new RegExp(/\$\(.*\)\$/)), new TwitterCldr.TokenRecognizer("semicolon", new RegExp(/;/))];
+      var r, recognizers, splitter, splitter_source;
+      recognizers = [new TwitterCldr.TokenRecognizer("negative", new RegExp(/-x/)), new TwitterCldr.TokenRecognizer("improper_fraction", new RegExp(/x\.x/)), new TwitterCldr.TokenRecognizer("proper_fraction", new RegExp(/0\.x/)), new TwitterCldr.TokenRecognizer("master", new RegExp(/x\.0/)), new TwitterCldr.TokenRecognizer("equals", new RegExp(/\=/)), new TwitterCldr.TokenRecognizer("rule", TwitterCldr.RBNFTokenizer.get_rule_regexp()), new TwitterCldr.TokenRecognizer("right_arrow", new RegExp(/>/)), new TwitterCldr.TokenRecognizer("left_arrow", new RegExp(/</)), new TwitterCldr.TokenRecognizer("open_bracket", new RegExp(/\[/)), new TwitterCldr.TokenRecognizer("close_bracket", new RegExp(/\]/)), new TwitterCldr.TokenRecognizer("decimal", new RegExp(/[0#][0#,\.]+/)), new TwitterCldr.TokenRecognizer("plural", new RegExp(/\$\(.*\)\$/)), new TwitterCldr.TokenRecognizer("semicolon", new RegExp(/;/))];
       splitter_source = "(" + (((function() {
         var _i, _len, _results;
         _results = [];
@@ -3448,6 +3450,23 @@
       var tokenizer;
       tokenizer = new TwitterCldr.PatternTokenizer(null, this.tokenizer);
       return tokenizer.tokenize(pattern);
+    };
+
+    RBNFTokenizer.get_rule_regexp = function() {
+      var component, word_regexp_components;
+      if (this.rule_regexp != null) {
+        return this.rule_regexp;
+      }
+      word_regexp_components = ["Ll", "Lm", "Lo", "Lt", "Lu", "Mc", "Me", "Mu", "Nd", "Nl", "No", "Pc", "Pd"];
+      return this.rule_regexp = TwitterCldr.UnicodeRegex.compile("%%?[" + ((function() {
+        var _i, _len, _results;
+        _results = [];
+        for (_i = 0, _len = word_regexp_components.length; _i < _len; _i++) {
+          component = word_regexp_components[_i];
+          _results.push("[:" + component + ":]");
+        }
+        return _results;
+      })()).join("") + "]*").to_regexp();
     };
 
     return RBNFTokenizer;
@@ -4138,13 +4157,13 @@
           if (rule_set.is_public()) {
             return TwitterCldr.RBNFRuleFormatter.format(number, rule_set, rule_group, this.locale);
           } else {
-            throw rule_set_name + " is a private rule set and cannot be used directly.";
+            throw "" + rule_set_name + " is a private rule set and cannot be used directly.";
           }
         } else {
-          throw "rule set - " + rule_set_name + " - not implemented";
+          throw new TwitterCldr.NotImplementedException("rule set - " + rule_set_name + " - not implemented");
         }
       } else {
-        throw "rule group - " + rule_group_name + " - not implemented";
+        throw new TwitterCldr.NotImplementedException("rule group - " + rule_group_name + " - not implemented");
       }
     };
 

--- a/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/rbnf.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/rbnf.coffee
@@ -28,11 +28,11 @@ class TwitterCldr.RBNF
         if rule_set.is_public()
           TwitterCldr.RBNFRuleFormatter.format(number, rule_set, rule_group, @locale)
         else
-          throw rule_set_name + " is a private rule set and cannot be used directly."
+          throw "#{rule_set_name} is a private rule set and cannot be used directly."
       else
-        throw "rule set - #{rule_set_name} - not implemented"
+        throw new TwitterCldr.NotImplementedException("rule set - #{rule_set_name} - not implemented")
     else
-      throw "rule group - #{rule_group_name} - not implemented"
+      throw new TwitterCldr.NotImplementedException("rule group - #{rule_group_name} - not implemented")
 
   group_names : ->
     group['type'] for group in @get_resource_for_locale()

--- a/lib/twitter_cldr/js/mustache/utilities.coffee
+++ b/lib/twitter_cldr/js/mustache/utilities.coffee
@@ -142,3 +142,7 @@ class TwitterCldr.Utilities
       else
         return null
     value
+
+class TwitterCldr.NotImplementedException extends Error
+  constructor: (@message = "") ->
+    super

--- a/spec/js/numbers/rbnf.spec.js
+++ b/spec/js/numbers/rbnf.spec.js
@@ -27,14 +27,16 @@ function rbnf_test_case (locale, rule_group, rule_set, test_case) {
       TwitterCldr.set_data(data_backup);
     });
 
-    it('formats test_case correctly', function() {
+    it('formats ' + test_case + ' correctly', function() {
       try {
         var got = formatter.format(TwitterCldr.PluralRules.runtime.toNum(test_case), rule_group, rule_set);
         var expected = TwitterCldr.RBNF.test_resource[locale][rule_group][rule_set][test_case];
         expect(got).toEqual(expected);
       }
       catch (error) {
-        // Ignore `Not implemented` errors.
+        if (!(error instanceof TwitterCldr.NotImplementedException)) {
+            throw error;
+        }
       }
     });
   });

--- a/spec/js/numbers/rbnf.spec.js
+++ b/spec/js/numbers/rbnf.spec.js
@@ -35,7 +35,7 @@ function rbnf_test_case (locale, rule_group, rule_set, test_case) {
       }
       catch (error) {
         if (!(error instanceof TwitterCldr.NotImplementedException)) {
-            throw error;
+          throw error;
         }
       }
     });
@@ -43,13 +43,15 @@ function rbnf_test_case (locale, rule_group, rule_set, test_case) {
 }
 
 for (var locale in TwitterCldr.RBNF.test_resource) {
-
   if (["ar", "ja", "ko", "zh", "ja", "zh-Hant", "ja", "hi", "ta"].indexOf(locale) !== -1)
     continue;
   for (var rule_group in TwitterCldr.RBNF.test_resource[locale]) {
     if (formatter.group_names().indexOf(rule_group) === -1)
       continue;
     for (var rule_set in TwitterCldr.RBNF.test_resource[locale][rule_group]) {
+      if (!process.env.FULL_TEST_SUITE && rule_set !== 'spellout-numbering') {
+        continue;
+      }
       if (formatter.rule_set_names_for_group(rule_group).indexOf(rule_set) === -1)
         continue;
       for (var test_case in TwitterCldr.RBNF.test_resource[locale][rule_group][rule_set]) {


### PR DESCRIPTION
- Only `spellout-numbering` tests are run by default
- The whole suite can be run by using the `spec:js:full` task
- The whole suite runs on travis

Otherwise the tests take too long because there are about 30k of them(!)

@camertron @KL-7 