### PR TITLE
Hardcode @name to function name, like NumberFormatter. Increate compatibility to IE

### DIFF
--- a/lib/assets/javascripts/twitter_cldr/core.js
+++ b/lib/assets/javascripts/twitter_cldr/core.js
@@ -231,11 +231,11 @@
     function Settings() {}
 
     Settings.is_rtl = function() {
-      return TwitterCldr.get_data()[this.name].is_rtl;
+      return TwitterCldr.get_data().Settings.is_rtl;
     };
 
     Settings.locale = function() {
-      return TwitterCldr.get_data()[this.name].locale;
+      return TwitterCldr.get_data().Settings.locale;
     };
 
     return Settings;
@@ -326,7 +326,7 @@
 ;
 
     PluralRules.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().PluralRules;
     };
 
     PluralRules.all = function(type) {
@@ -369,7 +369,7 @@
     }
 
     TimespanFormatter.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().TimespanFormatter;
     };
 
     TimespanFormatter.prototype.patterns = function() {
@@ -471,7 +471,7 @@
     }
 
     DateTimeFormatter.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().DateTimeFormatter;
     };
 
     DateTimeFormatter.prototype.tokens = function() {
@@ -1007,7 +1007,7 @@
     function ListFormatter() {}
 
     ListFormatter.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().ListFormatter;
     };
 
     ListFormatter.prototype.formats = function() {
@@ -1503,7 +1503,7 @@
     }
 
     BreakIterator.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().BreakIterator;
     };
 
     BreakIterator.prototype.each_sentence = function(str, block) {
@@ -1683,7 +1683,7 @@
     REDIRECT_PREFIX = "calendars.gregorian.";
 
     Calendar.calendar = function() {
-      return TwitterCldr.get_data()[this.name].calendar;
+      return TwitterCldr.get_data().Calendar.calendar;
     };
 
     Calendar.months = function(options) {
@@ -1758,7 +1758,7 @@
     CodePoint.properties = ["sentence_break", "line_break", "word_break"];
 
     CodePoint.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().CodePoint;
     };
 
     function CodePoint(fields) {
@@ -2045,7 +2045,7 @@
     function Languages() {}
 
     Languages.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().Languages;
     };
 
     Languages.all = function() {
@@ -2211,7 +2211,7 @@
     }
 
     NumberParser.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().NumberParser;
     };
 
     NumberParser.prototype.group_separator = function() {
@@ -4135,7 +4135,7 @@
     }
 
     RBNF.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().RBNF;
     };
 
     RBNF.prototype.resource = function() {
@@ -4320,7 +4320,7 @@
     }
 
     NumberDataReader.data = function() {
-      return TwitterCldr.get_data()[this.name];
+      return TwitterCldr.get_data().NumberDataReader;
     };
 
     NumberDataReader.prototype.resource = function() {

--- a/lib/assets/javascripts/twitter_cldr/test_resources.js
+++ b/lib/assets/javascripts/twitter_cldr/test_resources.js
@@ -2,7 +2,7 @@
 // Copyright 2012 Twitter, Inc
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// TwitterCLDR (JavaScript) v3.0.0
+// TwitterCLDR (JavaScript) v3.1.0
 // Authors:     Cameron Dutro [@camertron]
                 Kirill Lashuk [@KL_7]
                 portions by Sven Fuchs [@svenfuchs]

--- a/lib/twitter_cldr/js/mustache/implementation/calendars/datetime.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/calendars/datetime.coffee
@@ -34,7 +34,7 @@ class TwitterCldr.DateTimeFormatter
       'V': 'timezone_metazone'
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().DateTimeFormatter
 
   tokens: ->
     @constructor.data().tokens

--- a/lib/twitter_cldr/js/mustache/implementation/calendars/timespan.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/calendars/timespan.coffee
@@ -16,7 +16,7 @@ class TwitterCldr.TimespanFormatter
     }
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().TimespanFormatter
 
   patterns: ->
     @constructor.data().patterns

--- a/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/number_data_reader.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/number_data_reader.coffee
@@ -53,7 +53,7 @@ class TwitterCldr.NumberDataReader
     @number_data = {}
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().NumberDataReader
 
   resource : ->
     @constructor.data().resource

--- a/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/rbnf.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/numbers/rbnf/rbnf.coffee
@@ -11,7 +11,7 @@ class TwitterCldr.RBNF
     @rule_set_name_cache = {}
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().RBNF
 
   resource : ->
     @constructor.data().resource

--- a/lib/twitter_cldr/js/mustache/implementation/parsers/number_parser.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/parsers/number_parser.coffee
@@ -6,7 +6,7 @@ class TwitterCldr.NumberParser
     @separator_chars = ['\\.', ',', '\\s'].join("")
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().NumberParser
 
   group_separator: ->
     @constructor.data().group_separator

--- a/lib/twitter_cldr/js/mustache/implementation/plurals/rules.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/plurals/rules.coffee
@@ -5,7 +5,7 @@ class TwitterCldr.PluralRules
   @runtime = `{{{runtime}}}`
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().PluralRules
 
   @all: (type = 'cardinal') ->
     return @data().names[type]

--- a/lib/twitter_cldr/js/mustache/implementation/settings.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/settings.coffee
@@ -3,7 +3,7 @@
 
 class TwitterCldr.Settings
   @is_rtl: ->
-    TwitterCldr.get_data()[@name].is_rtl
+    TwitterCldr.get_data().Settings.is_rtl
 
   @locale: ->
-  	TwitterCldr.get_data()[@name].locale
+  	TwitterCldr.get_data().Settings.locale

--- a/lib/twitter_cldr/js/mustache/implementation/shared/break_iterator.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/shared/break_iterator.coffee
@@ -10,7 +10,7 @@ class TwitterCldr.BreakIterator
     @segmentation_parser = new TwitterCldr.SegmentationParser()
 
   @data :->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().BreakIterator
 
   each_sentence : (str, block) ->
     @each_boundary(str, "sentence", block)

--- a/lib/twitter_cldr/js/mustache/implementation/shared/calendar.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/shared/calendar.coffee
@@ -5,7 +5,7 @@ class TwitterCldr.Calendar
   REDIRECT_PREFIX = "calendars.gregorian."
 
   @calendar: ->
-    TwitterCldr.get_data()[@name].calendar
+    TwitterCldr.get_data().Calendar.calendar
 
   @months: (options = {}) ->
     root = @get_root("months", options)

--- a/lib/twitter_cldr/js/mustache/implementation/shared/code_point.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/shared/code_point.coffee
@@ -26,7 +26,7 @@ class TwitterCldr.CodePoint
   @properties = ["sentence_break", "line_break", "word_break"]
 
   @data :->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().CodePoint
 
   constructor : (@fields) ->
     for i in [0...TwitterCldr.CodePoint.code_point_fields.length] by 1

--- a/lib/twitter_cldr/js/mustache/implementation/shared/languages.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/shared/languages.coffee
@@ -4,7 +4,7 @@
 class TwitterCldr.Languages
 
   @data: ->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().Languages
 
   @all: ->
   	@data().all

--- a/lib/twitter_cldr/js/mustache/implementation/shared/lists.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/shared/lists.coffee
@@ -3,7 +3,7 @@
 
 class TwitterCldr.ListFormatter
   @data :->
-    TwitterCldr.get_data()[@name]
+    TwitterCldr.get_data().ListFormatter
 
   formats: ->
     @constructor.data().formats


### PR DESCRIPTION
### Problem
On IE11 (maybe previous too) it's impossible to use `DateTimeFormatter`.

### Cause
Coffeescript use `@name` into some functions. This generates `this.name` and it doesn't work with IE11.

### Proposition
Hardcode CoffeeScript `@name` on following functions with function name :  
- Settings
- PluralRules
- TimespanFormatter
- DateTimeFormatter
- ListFormatter
- BreakIterator 
- Calendar
- CodePoint
- Languages
- NumberParser
- RBNF
- NumberDataReader

This is already present for `NumberFormatter` [see commit](https://github.com/twitter/twitter-cldr-js/commit/15f666c18b2b74578b07da20d0145772110ee208#diff-b55f8e1789dc6ebe61291bf2b68f5c1eR3581)
