### PR TITLE
Use https instead of http in urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 

--- a/spec/js/shared/break_iterator.spec.js
+++ b/spec/js/shared/break_iterator.spec.js
@@ -27,10 +27,10 @@ describe("BreakIterator", function() {
     });
 
     it("does not split periods in the midst of other letters, eg. in a URL", function() {
-      var str = "Visit us. Go to http://translate.twitter.com.";
+      var str = "Visit us. Go to https://translate.twitter.com.";
       expect(iterator.each_sentence(str)).toEqual([
         "Visit us.",
-        " Go to http://translate.twitter.com."
+        " Go to https://translate.twitter.com."
       ]);
     });
 

--- a/twitter_cldr_js.gemspec
+++ b/twitter_cldr_js.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version  = ::TwitterCldr::Js::VERSION
   s.authors  = ["Cameron Dutro"]
   s.email    = ["cdutro@twitter.com"]
-  s.homepage = "http://twitter.com"
+  s.homepage = "https://twitter.com"
 
   s.description = s.summary = "Provides date, time, number, and list formatting functionality for various Twitter-supported locales in Javascript."
 


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.