### PR TITLE
Correct UnicodeRegex documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,13 +429,22 @@ regex3 = TwitterCldr.UnicodeRegex.compile("[[a-z]-[d-g]]+", "g");
 							//supports the JavaScript RegExp modifiers
 ```
 
-Once compiled, instances of `UnicodeRegex` behave just like normal javascript regexes and support the `match` method:
+Once compiled, instances of `UnicodeRegex` can be directly used to match against a string:
 
 ```javascript
 
 regex.match("ABC");  // ["ABC"]
 regex2.match("ABCDfooABC");  // ["ABCD", "ABC"]
 regex3.match("dog"); // ["o"]
+```
+
+Alternatively, you can convert a `UnicodeRegex` into a native JavaScript regex by calling its `to_regexp` method:
+
+```javascript
+
+regex3.to_regexp(); // /(?:[\u0061-\u0063]|[\u0068-\u007a])+/g
+regex3.to_regexp().test("a"); // true
+regex3.to_regexp().test("d"); // false
 ```
 
 Protip: Try to avoid negation in character classes (eg. [^abc] and \P{Lu}) as it tends to negatively affect both performance when constructing regexes as well as matching.


### PR DESCRIPTION
Per current README:

https://github.com/twitter/twitter-cldr-js/blob/d2049f9d8b3cef1890ec6e315f291f1b40ed541f/README.md?plain=1#L432

This is incorrect — JS regexes have methods such as `test`, `exec`, etc. but they don't have a `match` method. JS _strings_ have a `match` method that can take a regex as an argument:

```js
const re = new RegExp('.', '')
re.test('a') // true
re.exec('a') // ['a', index: 0, input: 'a', groups: undefined]
'a'.match(re) // ['a', index: 0, input: 'a', groups: undefined]
re.match('a') // Uncaught TypeError: re.match is not a function
```

In contrast:

```js
const re = TwitterCldr.UnicodeRegex.compile('.', '')
re.test('a') // Uncaught TypeError: re.test is not a function
re.exec('a') // Uncaught TypeError: re.exec is not a function
'a'.match(re) // null
re.match('a') // ['a']
```