### PR TITLE
Expose available locales and file names

### DIFF
--- a/lib/twitter_cldr/js/compiler.rb
+++ b/lib/twitter_cldr/js/compiler.rb
@@ -97,7 +97,7 @@ module TwitterCldr
           }
         end
 
-        bundle[:available_locales] = available_locales.sort_by{ |x| x[:locale] }.to_json
+        bundle[:available_locales] = available_locales.sort_by { |x| x[:locale] }.to_json
 
         file = compile_bundle(bundle, @features, implementation_renderers, options)
 

--- a/lib/twitter_cldr/js/compiler.rb
+++ b/lib/twitter_cldr/js/compiler.rb
@@ -89,6 +89,16 @@ module TwitterCldr
       def compile_implementation(options = {})
         bundle = TwitterCldr::Js::Renderers::Bundle.new
         bundle[:locale] = TwitterCldr::DEFAULT_LOCALE
+
+        available_locales = @locales.map do |locale|
+          {
+            locale: locale,
+            file_name: TwitterCldr.twitter_locale(locale),
+          }
+        end
+
+        bundle[:available_locales] = available_locales.sort_by{ |x| x[:locale] }.to_json
+
         file = compile_bundle(bundle, @features, implementation_renderers, options)
 
         file.source

--- a/lib/twitter_cldr/js/mustache/bundle.coffee
+++ b/lib/twitter_cldr/js/mustache/bundle.coffee
@@ -23,6 +23,8 @@ TwitterCldr = {}
 {{> utilities}}
 {{{contents}}}
 
+TwitterCldr.get_available_locales = -> {{{available_locales}}}
+
 TwitterCldr.set_data = (bundle) ->
   TwitterCldr.data = bundle
   null


### PR DESCRIPTION
Replacement PR with same purpose as https://github.com/twitter/twitter-cldr-npm/pull/11 but generated automatically at compile time.

Pasting my reasoning from that one here for convenience:

> > Hmm this is interesting. Ordinarily locale fallbacks are calculated using parent locale data from the CLDR as is done [here](https://github.com/twitter/twitter-cldr-rb/blob/master/lib/twitter_cldr/resources/cldr_locale.rb) in twitter-cldr-rb. Absent these data, there should be some intelligent fallback mechanism the user can override. I like your idea of allowing people to provide their own matching rules. What do you think such a mechanism might look like?
> 
> I'm leaning toward simply exposing the list of file names, because the logic for which one to choose on an inexact match could be quite specific to each application. For example, for my use case, I'm now finding generic locales (`es` etc) are generally preferable to fully specified ones (`es-MX` etc), due to the generic locales having more complete data.
> 
> Perhaps the locales should be exposed too, as those don't always match up to the file names, and there's no consistent way of converting them:
> * Locale for file `zh-cn.js` is `zh` (remove region code)
> * Locale for file `zh-tw.js` is `zh-Hant` (swap out region code for script code)
> * Locale for file `en.js` is `en` (identical)
> * Locale for file `zh-GB.js` is `en-GB` (identical)
> * Locale for file `msa.js` is `ms` (2-letter vs 3-letter language code)
