### PR TITLE
Implement data isolation with TwitterCldr.clone

### DIFF
--- a/lib/twitter_cldr/js/compiler.rb
+++ b/lib/twitter_cldr/js/compiler.rb
@@ -152,7 +152,8 @@ module TwitterCldr
           :plural                          => TwitterCldr::Js::Renderers::Implementation::Numbers::RBNF::PluralRenderer,
           :range                           => TwitterCldr::Js::Renderers::Implementation::Utils::RangeRenderer,
           :range_set                       => TwitterCldr::Js::Renderers::Implementation::Utils::RangeSetRenderer,
-          :code_points                     => TwitterCldr::Js::Renderers::Implementation::Utils::CodePointsRenderer
+          :code_points                     => TwitterCldr::Js::Renderers::Implementation::Utils::CodePointsRenderer,
+          :clone                           => TwitterCldr::Js::Renderers::Implementation::Clone::CloneRenderer,
         }
       end
 

--- a/lib/twitter_cldr/js/mustache/implementation/clone/clone.coffee
+++ b/lib/twitter_cldr/js/mustache/implementation/clone/clone.coffee
@@ -1,0 +1,58 @@
+with_data_isolation = (data) -> (fn) ->
+  original = TwitterCldr.data
+  TwitterCldr.data = data
+  result = fn()
+  TwitterCldr.data = original
+  result
+
+get_with_data_isolation = (data) -> (target, property_key, receiver) ->
+  isolate_data = with_data_isolation(data)
+
+  isolate_data(->
+    result = Reflect.get(target, property_key, receiver)
+
+    if typeof result == 'function'
+      fn = result
+
+      result = (args...) -> isolate_data(-> Reflect.apply(fn, target, args))
+
+    result
+  )
+
+proxy_or_primitive = (value, handlers) ->
+  if value instanceof Object
+    new Proxy(value, handlers)
+  else
+    value
+
+TwitterCldr.clone = (data) ->
+  if !data
+    throw new Error('Cannot create a clone with no data')
+
+  get = get_with_data_isolation(data)
+  isolate_data = with_data_isolation(data)
+
+  proxy_or_primitive(
+    root,
+    get: (target, property_key, receiver) ->
+      switch property_key
+        when 'set_data'
+          return -> throw new Error('Cannot set data on a TwitterCldr clone')
+        else
+          isolate_data(
+            -> proxy_or_primitive(
+              Reflect.get(target, property_key, receiver), {
+                get,
+                apply: (args...) ->
+                  isolate_data(
+                    -> Reflect.apply(args...)
+                  )
+                construct: (args...) ->
+                  isolate_data(
+                    -> proxy_or_primitive(Reflect.construct(args...), { get })
+                  )
+              }
+            )
+          )
+    set: () -> throw new Error('Cannot set properties on a TwitterCldr clone')
+  )

--- a/lib/twitter_cldr/js/renderers.rb
+++ b/lib/twitter_cldr/js/renderers.rb
@@ -19,6 +19,7 @@ module TwitterCldr
         autoload :Numbers,                                'twitter_cldr/js/renderers/implementation/numbers'
         autoload :Parsers,                                'twitter_cldr/js/renderers/implementation/parsers'
         autoload :Tokenizers,                             'twitter_cldr/js/renderers/implementation/tokenizers'
+        autoload :Clone,                                  'twitter_cldr/js/renderers/implementation/clone'
 
       module Shared
           autoload :BidiRenderer,                         'twitter_cldr/js/renderers/implementation/shared/bidi_renderer'

--- a/lib/twitter_cldr/js/renderers/implementation/clone.rb
+++ b/lib/twitter_cldr/js/renderers/implementation/clone.rb
@@ -1,0 +1,20 @@
+# encoding: UTF-8
+
+# Copyright 2012 Twitter, Inc
+# http://www.apache.org/licenses/LICENSE-2.0
+
+module TwitterCldr
+  module Js
+    module Renderers
+      module Implementation
+        module Clone
+
+          class CloneRenderer < TwitterCldr::Js::Renderers::Base
+            set_template "mustache/implementation/clone/clone.coffee"
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/js/clone/clone.spec.js
+++ b/spec/js/clone/clone.spec.js
@@ -1,0 +1,234 @@
+const locales = "en,ar,ko,ru,hi".split(",");
+const date = new Date(2000, 1, 1);
+
+// Updated version of
+// https://github.com/twitter/twitter-cldr-npm/blob/master/twitter_cldr.js
+// that clones by default
+const load = function (locale, options) {
+  var defaultOptions = { clone: true };
+  options = options || {};
+
+  for (var k in defaultOptions) {
+    if (!(k in options)) {
+      options[k] = defaultOptions[k];
+    }
+  }
+
+  var TwitterCldr = require("../../../lib/assets/javascripts/twitter_cldr/core");
+  var data = require("../../../lib/assets/javascripts/twitter_cldr/" + locale);
+
+  if (options.clone) {
+    return TwitterCldr.clone(data);
+  } else {
+    TwitterCldr.set_data(data);
+    return TwitterCldr;
+  }
+};
+
+const checkDataIsolation = ({ class: klass, ctorParams, methods, staticMethods, loadOptions }) => {
+  methods = methods || {}
+  staticMethods = staticMethods || {}
+  ctorParams = ctorParams || []
+
+  describe(klass, () => {
+    const allMethods = [
+      ...(Object.entries(methods)).map(x => [false, ...x]),
+      ...(Object.entries(staticMethods)).map(x => [true, ...x]),
+    ]
+
+    for (let [static, name, { params, compare }] of allMethods) {
+      params = params || []
+      compare = compare || ((x) => x)
+
+      describe(`${static ? "." : "#"}${name}`, () => {
+        const twitterCldrs = locales.map((locale) => {
+          const params = [locale, loadOptions].filter((x) => x != null);
+          const TwitterCldr = load(...params);
+
+          return { locale, TwitterCldr };
+        });
+
+        const formatters = twitterCldrs.map(({ locale, TwitterCldr }) => {
+          const formatter = static ? TwitterCldr[klass] : new TwitterCldr[klass](...ctorParams)
+
+          return { locale, formatter };
+        });
+
+        const formatFns = formatters.map(({ locale, formatter }) => ({
+          locale,
+          format: formatter[name].bind(formatter),
+        }));
+
+        const results = formatFns.map(({ locale, format }) => ({
+          locale,
+          result: compare(format(...params)),
+        }));
+
+        it(`sanity check - result for same locale is equal`, () => {
+          const { formatter } = formatters[0];
+          const format = formatter[name].bind(formatter);
+
+          expect(compare(format(...params))).toBe(compare(format(...params)));
+        });
+
+        for (const [idx, { locale, result }] of results.entries()) {
+          const prevs = results.slice(0, idx);
+
+          if (!prevs.length) continue;
+
+          for (const prev of prevs) {
+            it(`result for "${locale}" differs from result for "${prev.locale}"`, () => {
+              expect(result).not.toBe(prev.result);
+            });
+          }
+        }
+      });
+    }
+  });
+};
+
+const tests = [
+  {
+    class: "DateTimeFormatter",
+    methods: {
+      format: { params: [date, { type: "full" }] },
+      weekday_local_stand_alone: { params: [date, "cc", 2] },
+    },
+  },
+  {
+    class: "Languages",
+    staticMethods: {
+      from_code: { params: ["en"] },
+      all: { params: [], compare: (x) => x.ja },
+    },
+  },
+  {
+    class: "RBNF",
+    methods: {
+      format: { params: [1, "SpelloutRules", "spellout-numbering"] },
+    },
+  }
+];
+
+describe("data isolation", () => {
+  for (const loadOptions of [
+    undefined, // no options param supplied
+    {}, // empty options - defaults to clone=true
+    { clone: true }, // explicitly specify clone=true
+  ]) {
+    tests.map((x) => ({ ...x, loadOptions })).forEach(checkDataIsolation);
+  }
+});
+
+describe("clone behavior", () => {
+  const TwitterCldr = require("../../../lib/assets/javascripts/twitter_cldr/core");
+  const en = require("../../../lib/assets/javascripts/twitter_cldr/en");
+  const ja = require("../../../lib/assets/javascripts/twitter_cldr/ja");
+
+  beforeEach(() => {
+    TwitterCldr.set_data(undefined);
+  })
+
+  afterEach(() => {
+    TwitterCldr.set_data(undefined);
+  });
+
+  const locale = (clone) => clone.get_data().Settings.locale;
+
+  it("can be cloned from base that has no data", () => {
+    const clone = TwitterCldr.clone(en);
+
+    expect(locale(clone)).toBe("en");
+    expect(TwitterCldr.is_data_set()).toBe(false);
+    expect(clone.is_data_set()).toBe(true);
+  });
+
+  it("returns undefined for properties not present on `root`", () => {
+    TwitterCldr.set_data(en);
+    const clone = TwitterCldr.clone(en);
+
+    expect(TwitterCldr.data).toBe(undefined);
+    expect(clone.data).toBe(undefined);
+  });
+
+  it("doesn't affect data of the base TwitterCldr", () => {
+    TwitterCldr.set_data(ja);
+    TwitterCldr.clone(en);
+
+    expect(locale(TwitterCldr)).toBe("ja");
+  });
+
+
+  it("isn't affected by data of the base TwitterCldr", () => {
+    const clone = TwitterCldr.clone(en);
+    TwitterCldr.set_data(ja);
+
+    expect(locale(clone)).toBe("en");
+  });
+
+  it("can be cloned indefinitely", () => {
+    const cloneEn1 = TwitterCldr.clone(en);
+    const cloneEn2 = cloneEn1.clone(en);
+    const cloneJa = cloneEn2.clone(ja);
+
+    expect(locale(cloneEn1)).toBe("en");
+    expect(locale(cloneEn2)).toBe(locale(cloneEn1));
+    expect(locale(cloneJa)).toBe("ja");
+  });
+
+  it("throws if attempting to create a clone with no data", () => {
+    expect(() => TwitterCldr.clone()).toThrow();
+    expect(() => TwitterCldr.clone(undefined)).toThrow();
+    expect(() => TwitterCldr.clone(null)).toThrow();
+
+    expect(() => TwitterCldr.clone({})).not.toThrow();
+  });
+
+  describe("cloned version throws if attempting to set data", () => {
+    const clone = TwitterCldr.clone(en);
+
+    it("using `set_data`", () => {
+      expect(() => clone.set_data({})).toThrow();
+    });
+
+    it("using `data = `", () => {
+      expect(() => clone.data = {}).toThrow();
+    });
+  });
+});
+
+describe("load(..., false)", () => {
+  describe("continues to use global state", () => {
+    const results = locales.map((locale) => {
+      const TwitterCldr = load(locale, { clone: false });
+      return new TwitterCldr.DateTimeFormatter();
+    }).map((formatter) => formatter.format(date, { type: "full" }));
+
+    describe("DateTimeFormatter", () => {
+      it("#format", () => {
+        expect(new Set(results).size).toEqual(1);
+      });
+    });
+  });
+
+  describe("works in environments without `Proxy` support", () => {
+    const originalProxy = globalThis.Proxy;
+
+    beforeEach(() => {
+      globalThis.Proxy = undefined;
+    });
+
+    afterEach(() => {
+      globalThis.Proxy = originalProxy;
+    });
+
+    describe("DateTimeFormatter", () => {
+      it("#weekday_local_stand_alone", () => {
+        const TwitterCldr = load("en", { clone: false });
+        const formatter = new TwitterCldr.DateTimeFormatter();
+
+        expect(formatter.weekday_local_stand_alone(date, "cc", 2)).toEqual("Tue");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/twitter/twitter-cldr-js/issues/77 (Global state leakage) while retaining backward compatibility and without re-loading the core library for each locale. Backward compatibility with this PR alone is 100% — the new functionality is all hidden behind `TwitterCldr.clone`, while `TwitterCldr.set_data` continues to use the original global-state behavior.

Technically speaking, this PR doesn't actually isolate any state at all; it just adds in a hook, implemented via proxies, that sneakily switches out the global state at opportune moments, then replaces it before anyone notices it's missing. So the state is _conceptually_ isolated (i.e. it's isolated from the library consumer's point of view), even though it's actually still global. I did look into refactoring the library to make `TwitterCldr` an instantiable class, but it would require a major refactor and be impossible to do in a backward-compatible way.

If this PR is accepted, I'd suggest one additional change to `twitter-cldr-npm`, namely changing the `load` function per https://github.com/twitter/twitter-cldr-js/compare/master...lionel-rowe:data-isolation?expand=1#diff-f80dc1f53c2405b271ed9beeb1bddc9f3367cd017a0cdc6682a61af8372b635eR7-R26. That would break backward compatibility, but in a relatively minor way — `twitterCldr.load` would now return a cloned version instead of a global-state version of `TwitterCldr`. This could be overriden by supplying `{ clone: false }` as an additional parameter. There would be 2 plausible use cases for _not_ wanting the clone behavior, both of which I'm guessing are pretty marginal:
1. Needing to support environments without `Proxy` support (IE11 or other legacy environments). As IE is officially dead, the crossover between projects that _both_ need to support IE _and_ need to update all their libraries to the latest versions must be pretty small.
2. Relying on the old global-state behavior. Difficult to say how common this use-case would be, but a quick regex search and replace of `twitterCldr\.load\(([^]+)\)` with `twitterCldr.load($1, { clone: false })` should fix it.

Alternatively, leaving `load` as-is and adding a `clone` wrapper to the NPM package's `module.exports` would retain 100% backward compatibility with the NPM package. Something like this:

```js
exports.clone = function (locale) {
  var TwitterCldr = require("../../../lib/assets/javascripts/twitter_cldr/core");
  var data = require("../../../lib/assets/javascripts/twitter_cldr/" + locale);

  return TwitterCldr.clone(data);
};
```
